### PR TITLE
Fix linking errors

### DIFF
--- a/ldecod/configfile.c
+++ b/ldecod/configfile.c
@@ -66,6 +66,8 @@
 #include "configfile.h"
 #define MAX_ITEMS_TO_PARSE  10000
 
+InputParameters cfgparams;
+
 static void PatchInp                (InputParameters *p_Inp);
 
 /*!

--- a/ldecod/configfile.h
+++ b/ldecod/configfile.h
@@ -17,8 +17,7 @@
 //#define PROFILE_IDC     88
 //#define LEVEL_IDC       21
 
-
-InputParameters cfgparams;
+extern InputParameters cfgparams;
 
 #ifdef INCLUDED_BY_CONFIGFILE_C
 // Mapping_Map Syntax:

--- a/ldecod/defines.h
+++ b/ldecod/defines.h
@@ -228,7 +228,7 @@ typedef enum {
 } I8x8PredModes;
 
 // Color components
-enum {
+typedef enum {
   Y_COMP = 0,    // Y Component
   U_COMP = 1,    // U Component
   V_COMP = 2,    // V Component


### PR DESCRIPTION
I was getting 68 lines of linking errors regarding `ldecod` when compiling `h264-tools`, all similar as the following line with only the first source file changing:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/ldecod.dir/biaridecod.c.o:(.bss+0x0): multiple definition of `ColorComponent'; CMakeFiles/ldecod.dir/annexb.c.o:(.bss+0x0): first defined here
```

After fixing that, I was getting the following linking error:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/ldecod.dir/configfile.c.o:(.bss+0x0): multiple definition of `cfgparams'; CMakeFiles/ldecod.dir/config_common.c.o:(.bss+0x0): first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/ldecod.dir/decoder_test.c.o:(.bss+0x0): multiple definition of `cfgparams'; CMakeFiles/ldecod.dir/config_common.c.o:(.bss+0x0): first defined here
```

This PR fixes both errors.